### PR TITLE
do not use `relative_to(home)` in path debugging

### DIFF
--- a/experiments/torch-train-test-debug-template.ipynb
+++ b/experiments/torch-train-test-debug-template.ipynb
@@ -26,7 +26,7 @@
    "source": [
     "# If this is the template file (and not a copy) and you are introducing changes,\n",
     "# update VERSION with the current date (YYYY.MM.DD)\n",
-    "VERSION = \"2021.04.09\""
+    "VERSION = \"2021.04.12\""
    ]
   },
   {
@@ -113,10 +113,10 @@
     "OUT = HERE / \"_output\" / datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
     "OUT.mkdir(parents=True, exist_ok=True)\n",
     "\n",
-    "print(f\"This notebook:           HERE = ~/{HERE.relative_to(Path.home())}\")\n",
-    "print(f\"This repo:               REPO = ~/{REPO.relative_to(Path.home())}\")\n",
-    "print(f\"Features:      FEATURES_STORE = ~/{FEATURES_STORE.relative_to(Path.home())}\")\n",
-    "print(f\"Outputs in:               OUT = ~/{OUT.relative_to(Path.home())}\")"
+    "print(f\"This notebook:           HERE = {HERE}\")\n",
+    "print(f\"This repo:               REPO = {REPO}\")\n",
+    "print(f\"Features:      FEATURES_STORE = {FEATURES_STORE}\")\n",
+    "print(f\"Outputs in:               OUT = {OUT}\")"
    ]
   },
   {

--- a/features/featurize-template.ipynb
+++ b/features/featurize-template.ipynb
@@ -32,7 +32,7 @@
    "source": [
     "# If this is the template file (and not a copy) and you are introducing changes,\n",
     "# update VERSION with the current date (YYYY.MM.DD)\n",
-    "VERSION = \"2021.04.08\" "
+    "VERSION = \"2021.04.12\" "
    ]
   },
   {
@@ -115,9 +115,9 @@
     "OUT = HERE / \"_output\"  / \"__\".join(featurizer_path) / DATASET_CLS.rsplit('.', 1)[1]\n",
     "OUT.mkdir(parents=True, exist_ok=True)\n",
     "\n",
-    "print(f\"This notebook:           HERE = ~/{HERE.relative_to(Path.home())}\")\n",
-    "print(f\"This repo:               REPO = ~/{REPO.relative_to(Path.home())}\")\n",
-    "print(f\"Outputs in:               OUT = ~/{OUT.relative_to(Path.home())}\")"
+    "print(f\"This notebook:           HERE = {HERE}\")\n",
+    "print(f\"This repo:               REPO = {REPO}\")\n",
+    "print(f\"Outputs in:               OUT = {OUT}\")"
    ]
   },
   {


### PR DESCRIPTION
Some platforms with shared network drives do not behave well under this assumption

Fixes #5 