### PR TITLE
Ligand-based experiments: EGFR subset

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## Description
+Provide a brief description of the PR's purpose here.
+
+## Todos
+Notable points that this PR has either accomplished or will accomplish.
+  - [ ] TODO 1
+
+## Questions
+- [ ] Question1
+
+## Status
+- [ ] Ready to go

--- a/experiments/001_example-ligand-only-morgan1024-EGFR-subset.py
+++ b/experiments/001_example-ligand-only-morgan1024-EGFR-subset.py
@@ -1,0 +1,42 @@
+# ----
+# This input file is designed for experiments/torch-train-test-debug-template.ipynb
+# ----
+
+
+# DATA -- Glob paths must be relative to the root of the repository: REPO / features
+PARQUET_FILES = [
+    "ligand-only-morgan1024-EGFR-subsample/_output/ligand__SmilesToLigandFeaturizer__MorganFingerprintFeaturizer_nbits=1024_radius=2/ChEMBLDatasetProvider/*.parquet",
+]
+
+# Model -- specified with the full import path to the class object
+MODEL_CLS = "kinoml.ml.torch_models.NeuralNetworkRegression"
+MODEL_KWARGS = {
+    "hidden_shape": 350
+}  # input_shape is defined dynamically during training
+
+# OPTIMIZER
+OPTIMIZER = "torch.optim.Adam"
+OPTIMIZER_KWARGS = {"lr": 0.001, "eps": 1e-7, "betas": [0.9, 0.999]}
+
+# LOSS FUNCTION
+LOSS = "torch.nn.MSELoss"
+LOSS_KWARGS = {}
+
+# TRAINING
+MAX_EPOCHS = 50
+VALIDATION = True
+EARLY_STOPPING_KWARGS = {}
+
+# DATALOADER
+DATALOADER_CLS = "torch.utils.data.DataLoader"
+BATCH_SIZE = 64
+TRAIN_TEST_SPLIT = 0.2
+SHUFFLE_SPLITS = True
+COLLATE_FN = None
+
+# Plot bootstrapping
+N_BOOTSTRAPS = 1
+BOOTSTRAP_SAMPLE_RATIO = 1
+
+# Output
+VERBOSE = False

--- a/features/ligand-only-morgan1024-EGFR-subsample.py
+++ b/features/ligand-only-morgan1024-EGFR-subsample.py
@@ -1,0 +1,37 @@
+# ----
+# This input file is designed for features/featurize-template.ipynb
+# ----
+
+# You can only use UPPERCASE variables for the names
+# Values can ONLY be strings, numbers, lists (not tuples!) or dicts
+
+DATASET_CLS = "kinoml.datasets.chembl.ChEMBLDatasetProvider"
+DATASET_KWARGS = {
+    "path_or_url": "https://github.com/openkinome/kinodata/releases/download/v0.3/EGFR-activities-chembl29-sample.zip",
+}
+
+PIPELINES = {
+    "ligand": [
+        ["kinoml.features.ligand.SmilesToLigandFeaturizer", {}],
+        [
+            "kinoml.features.ligand.MorganFingerprintFeaturizer",
+            {"nbits": 1024, "radius": 2},
+        ],
+    ]
+}
+
+PIPELINES_AGG = "kinoml.features.core.TupleOfArrays"
+PIPELINES_AGG_KWARGS = {}
+
+# Use keep=False to reduce the memory usage to a minimum
+# Use keep=True if you want to debug the featurization steps
+FEATURIZE_KWARGS = {"keep": False}
+
+GROUPS = [
+    [
+        "kinoml.datasets.groups.CallableGrouper",
+        {"function": "lambda measurement: type(measurement).__name__"},
+    ],  # by measurement type
+]
+
+TRAIN_TEST_VAL_KWARGS = {"idx_train": 0.8, "idx_test": 0.1, "idx_val": 0.1}

--- a/tests/experiments/test_model_ligand_only.sh
+++ b/tests/experiments/test_model_ligand_only.sh
@@ -6,6 +6,11 @@ echo "Models"
 
 echo "Ligand only"
 
+echo "Running model for '001_example-ligand-only-morgan1024-EGFR-subset'"
+python run_notebook.py experiments/torch-train-test-debug-template.ipynb experiments/001_example-ligand-only-morgan1024-EGFR-subset.py --overwrite
+
+# These won't run because there are not enough data points for each kinase on the sample data.
+
 # echo "Running model for '001_example-ligand-only-morgan1024-subset'"
 # python run_notebook.py experiments/torch-train-test-debug-template.ipynb experiments/001_example-ligand-only-morgan1024-subset.py --overwrite
 

--- a/tests/features/test_featurization_ligand_only.sh
+++ b/tests/features/test_featurization_ligand_only.sh
@@ -6,6 +6,9 @@ echo "Featurization"
 
 echo "Ligand only"
 
+echo "Running featurization for 'ligand-only-morgan1024-EGFR-subsample'"
+python run_notebook.py features/featurize-template.ipynb features/ligand-only-morgan1024-EGFR-subsample.py --overwrite
+
 echo "Running featurization for 'ligand-only-morgan1024-subsample'"
 python run_notebook.py features/featurize-template.ipynb features/ligand-only-morgan1024-subsample.py --overwrite
 


### PR DESCRIPTION
## Description
If we try to train models using ligand-only information (i.e. train one model per kinase) and we use only the chembl 100 point sample, then the notebooks won't run, because there are not enough data points to evaluate specific metrics.
This PR finds a workaround: it focuses on the EGFR kinase, which has sufficient data points, so much that we take only a sample of 100 for testing. EGFR bioactivities and the 100 point sample are retrieved from kinodata, see https://github.com/openkinome/kinodata/releases/tag/v0.3 

## TODOS
- [x] Add featurization for a sample of the EGFR data for ligands as morgan fingerprint
- [x] Run a machine learning model based on this featurization
- [x] Add PR template while we're at it. 

## Status
- [x] Ready to go